### PR TITLE
Update for changes to DeviantART since...Wix acquisition, I think

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Please go to https://www.deviantart.com/settings/browsing. In "**General Browsin
 
 On the intital run, we need to add your login credential to your users ~/.netrc file, so we don't leave your username and password in the process ID, which could be seen by other users on the system (note: the initial run of this script will show up in your bash history).
 
-`ruby fetch.rb YOUR_USERNAME YOUR_PASSWORD http://azoexevan.deviantart.com/gallery/`
+`ruby fetch.rb YOUR_USERNAME YOUR_PASSWORD https://deviantart.com/azoexevan/gallery/`
 
 An entry in ~/.netrc is created for you. You can then use '-n' and it will poll the netrc file for your login credentials.
 
-`ruby fetch.rb -n http://azoexevan.deviantart.com/gallery/`
+`ruby fetch.rb -n https://deviantart.com/azoexevan/gallery/`

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Please go to https://www.deviantart.com/settings/browsing. In "**General Browsin
 
 On the intital run, we need to add your login credential to your users ~/.netrc file, so we don't leave your username and password in the process ID, which could be seen by other users on the system (note: the initial run of this script will show up in your bash history).
 
-`ruby fetch.rb YOUR_USERNAME YOUR_PASSWORD https://deviantart.com/azoexevan/gallery/`
+`ruby fetch.rb YOUR_USERNAME YOUR_PASSWORD https://www.deviantart.com/azoexevan/gallery/`
 
 An entry in ~/.netrc is created for you. You can then use '-n' and it will poll the netrc file for your login credentials.
 
-`ruby fetch.rb -n https://deviantart.com/azoexevan/gallery/`
+`ruby fetch.rb -n https://www.deviantart.com/azoexevan/gallery/`

--- a/lib/deviantart_gallery_downloader.rb
+++ b/lib/deviantart_gallery_downloader.rb
@@ -256,9 +256,9 @@ class DeviantartGalleryDownloader
     file_id = title_elem['href'].split('-').last
     
     if is_image
-      file_ext = @agent.page.parser.css(".dev-page-button.dev-page-button-with-text.dev-page-download").text.split(' ')[1] # Use the 'download' button, if it exists, to figure out the file extension.
+      file_ext = @agent.page.parser.css(".dev-page-button.dev-page-button-with-text.dev-page-download").text.split(' ')[1] # The download URL no longer has the file type extension, so we have to use the text from the download button itself.
 	  if file_ext.nil?
-		file_ext = 'jpg' # if there's no download button, we need to pick something, and it's probably an image...
+		file_ext = @agent.page.parser.css(".dev-content-full").map{|img| img["src"]}[0].split('.').last # if there's no download button, but the file type is an image, we can use the URL from the full-view element (which still has the file type extension)
 	  end
       puts "(#{index + 1}/#{image_page_links.count})Downloading \"#{title}\""
     else

--- a/lib/deviantart_gallery_downloader.rb
+++ b/lib/deviantart_gallery_downloader.rb
@@ -11,7 +11,7 @@ class DeviantartGalleryDownloader
     @agent.user_agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36'
     @agent.request_headers = { 'Referer' => 'https://www.deviantart.com/' }
     @gallery_url = ARGV.size == 3 ? ARGV[2].to_s : ARGV[1].to_s
-    @author_name = @gallery_url.split('.').first.split('//').last
+    @author_name = @gallery_url.split('.com/').last.split('/').first
   end
 
   def fetch
@@ -256,7 +256,10 @@ class DeviantartGalleryDownloader
     file_id = title_elem['href'].split('-').last
     
     if is_image
-      file_ext = file_name.split('.').last
+      file_ext = @agent.page.parser.css(".dev-page-button.dev-page-button-with-text.dev-page-download").text.split(' ')[1] # Use the 'download' button, if it exists, to figure out the file extension.
+	  if file_ext.nil?
+		file_ext = 'jpg' # if there's no download button, we need to pick something, and it's probably an image...
+	  end
       puts "(#{index + 1}/#{image_page_links.count})Downloading \"#{title}\""
     else
       file_ext = 'htm'


### PR DESCRIPTION
DA has changed how they store their files.  The most obvious change is that the URLs are no longer ```username.deviantart.com``` but now ```deviantart.com/username```.  Secondly, the link in the download button has no file extension in it, so we have to get that information from the download button's text field (otherwise it grabs a bunch of alphanumeric garbage from the URL to be the file extension).