### PR TITLE
Add support for per-page downloads, and fetching favourites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,24 @@
 # Change log
+- [2022-03-07]
+  - Refactored commandline processing; add requirement for 'getopt/std'
+  - Added "-p" option to download one page of 24 at a time
+  - Added support for "favourites":
+    - https://www.deviantart.com/kalfy/favourites
+    - https://www.deviantart.com/kalfy/favourites/all
+    - https://www.deviantart.com/kalfy/favourites/72183557/characters
 - [2021-02-19]
   - DeviantArt have refactored their frontend, guys must git pull the newest master branch to use.
   - `ruby fetch.rb -n https://www.deviantart.com/kalfy/gallery/all` can get the 'all' folder of an author, no need for dev branch any more.
 
 # Before use
 
-[Mechanize](http://mechanize.rubyforge.org) and netrc are needed:
+[Getopt](https://github.com/djberg96/getopt), [Mechanize](http://mechanize.rubyforge.org), and netrc are needed:
 
 `bundle` if u have Bundler installed.
 
 or
 
-`sudo gem install mechanize netrc`
+`sudo gem install mechanize netrc getopt`
 
 # Deviantart account setting
 
@@ -26,6 +33,18 @@ On the intital run, we need to add your login credential to your users ~/.netrc 
 
 An entry in ~/.netrc is created for you. You can then use '-n' and it will poll the netrc file for your login credentials.
 
-- (Featured)      `ruby fetch.rb -n https://www.deviantart.com/kalfy/gallery`
-- (all)           `ruby fetch.rb -n https://www.deviantart.com/kalfy/gallery/all`
-- (some gallery)  `ruby fetch.rb -n https://www.deviantart.com/kalfy/gallery/72183557/characters`
+For large galleries, you can use the "-p" option to download one page at a time:
+
+`ruby fetch.rb -p 1 YOUR_USERNAME YOUR_PASSWORD https://www.deviantart.com/kalfy/gallery`
+or
+`ruby fetch.rb -p 1 -n https://www.deviantart.com/kalfy/gallery`
+
+For a large gallery with, for example, 57 pages: (assuming bash shell on Linux)
+`for i in {1..57} ; do ruby fetch.rb -p $i -n https://www.deviantart.com/kalfy/gallery ; sleep 60 ; done`
+
+- (Featured)              `ruby fetch.rb -n https://www.deviantart.com/kalfy/gallery`
+- (all)                   `ruby fetch.rb -n https://www.deviantart.com/kalfy/gallery/all`
+- (some gallery)          `ruby fetch.rb -n https://www.deviantart.com/kalfy/gallery/72183557/characters`
+- (Favourites)            `ruby fetch.rb -n https://www.deviantart.com/kalfy/favourites`
+- (All Favourites)        `ruby fetch.rb -n https://www.deviantart.com/kalfy/favourites/all`
+- (Favourites gallery)    `ruby fetch.rb -n https://www.deviantart.com/kalfy/favourites/72183557/characters`


### PR DESCRIPTION
When fetching large galleries, deviantart sometimes flsgs it as suspicious and temporarily blocks the user account. To work around this, I added a "-p" option to download one page of 24 images at a time. I typically run the command within a for-loop in the shell, and have it sleep for a minute between pages.

I also added support for the three variants of "favourites"